### PR TITLE
feat: implement pet search by ID with error handling and Swagger documentation

### DIFF
--- a/src/main/java/io/zutun/samples/adapter/in/web/FindPetByIdController.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/FindPetByIdController.java
@@ -1,0 +1,63 @@
+package io.zutun.samples.adapter.in.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.zutun.samples.domain.Pet;
+import io.zutun.samples.exception.ErrorResponse;
+import io.zutun.samples.usecases.FindPetByIdUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Tag(name = "Pets", description = "Pets operations")
+@RestController
+@RequestMapping("/v1/pets")
+@RequiredArgsConstructor
+public class FindPetByIdController {
+
+    private final FindPetByIdUseCase findPetByIdUseCase;
+
+    @Operation(
+            summary = "Get a pet by ID",
+            description = "Returns a pet by its ID",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successful response",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = FindPetByIdResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Pet not found",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
+    @GetMapping("/{id}")
+    public ResponseEntity<FindPetByIdResponse> getPetById(@PathVariable UUID id) {
+        Pet pet = findPetByIdUseCase.findById(id);
+        return ResponseEntity.ok(new FindPetByIdResponse(pet));
+    }
+
+    public record FindPetByIdResponse(UUID id, String name, String breed, String color, LocalDate age) {
+        public FindPetByIdResponse(Pet pet) {
+            this(pet.getId(), pet.getName(), pet.getBreed(), pet.getColor(), pet.getBirthDate());
+        }
+    }
+
+}

--- a/src/main/java/io/zutun/samples/exception/ErrorResponse.java
+++ b/src/main/java/io/zutun/samples/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package io.zutun.samples.exception;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ErrorResponse(
+
+                            @Schema(description = "Timestamp of the error", example = "2025-04-27T12:34:56Z")
+                            String timestamp,
+                            @Schema(description = "Detailed error message", example = "Pet not found with ID: 3fa85f64-5717-4562-b3fc-2c963f66afa6")
+                            String message,
+                            @Schema(description = "HTTP status code", example = "404")
+                            Integer statusCode) {
+}

--- a/src/main/java/io/zutun/samples/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/zutun/samples/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package io.zutun.samples.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.Instant;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PetNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePetNotFoundException(PetNotFoundException ex) {
+        String message = ex.getMessage();
+        ErrorResponse errorResponse = new ErrorResponse(Instant.now().toString(), message, 404);
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                Instant.now().toString(),
+                ex.getMessage(),
+                500
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/io/zutun/samples/exception/PetNotFoundException.java
+++ b/src/main/java/io/zutun/samples/exception/PetNotFoundException.java
@@ -1,0 +1,10 @@
+package io.zutun.samples.exception;
+
+
+import java.util.UUID;
+
+public class PetNotFoundException extends RuntimeException {
+    public PetNotFoundException(UUID id) {
+        super("Pet not found with ID: " + id.toString());
+    }
+}

--- a/src/main/java/io/zutun/samples/service/FindPetByIdService.java
+++ b/src/main/java/io/zutun/samples/service/FindPetByIdService.java
@@ -1,0 +1,23 @@
+package io.zutun.samples.service;
+
+import io.zutun.samples.domain.Pet;
+import io.zutun.samples.exception.PetNotFoundException;
+import io.zutun.samples.usecases.FindPetByIdUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class FindPetByIdService  implements FindPetByIdUseCase {
+
+    private final PetsRepository petRepository;
+
+    @Override
+    public Pet findById(UUID id) {
+        return petRepository.findById(id)
+                .orElseThrow(() -> new PetNotFoundException(id));
+    }
+}

--- a/src/main/java/io/zutun/samples/usecases/FindPetByIdUseCase.java
+++ b/src/main/java/io/zutun/samples/usecases/FindPetByIdUseCase.java
@@ -1,0 +1,9 @@
+package io.zutun.samples.usecases;
+
+import io.zutun.samples.domain.Pet;
+
+import java.util.UUID;
+
+public interface FindPetByIdUseCase {
+    Pet findById(UUID id);
+}

--- a/src/test/java/io/zutun/samples/it/steps/ApiSteps.java
+++ b/src/test/java/io/zutun/samples/it/steps/ApiSteps.java
@@ -60,4 +60,9 @@ public class ApiSteps {
                 .then()
                 .body(field, matchesPattern("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"));
     }
+
+    @Cuando("Se busca una mascota con ID {string}")
+    public void searchPetById(String id) {
+        apiClient.performRequest(GET, "/v1/pets/" + id);
+    }
 }

--- a/src/test/resources/api/features/002_pet_find_by_id.feature
+++ b/src/test/resources/api/features/002_pet_find_by_id.feature
@@ -1,0 +1,10 @@
+# language: es
+Característica: Buscar una mascota por ID
+
+  Escenario: Buscar una mascota existente por su ID
+
+  Escenario: Buscar una mascota inexistente por su ID
+
+  Escenario: Buscar una mascota proporcionando un ID inválido
+
+  Escenario: Manejar un error interno inesperado al buscar una mascota"


### PR DESCRIPTION
## Description
This pull request introduces the functionality to retrieve a pet by its ID through a RESTful API endpoint. 

It includes:
- New use case (`FindPetByIdUseCase`) and service implementation.
- Controller endpoint with appropriate Swagger documentation.
- Global error handling with a standardized `ErrorResponse` record.
- Specific exception `PetNotFoundException` for cases when the pet does not exist.
- Updated OpenAPI specification for successful and error responses.

## Changes
- Added `FindPetByIdUseCase` interface and `FindPetByIdService` implementation.
- Created `FindPetByIdController` exposing the `/v1/pets/{id}` endpoint.
- Implemented `ErrorResponse` record for consistent API error payloads.
- Configured `GlobalExceptionHandler` for centralized exception handling.
- Integrated Swagger annotations for better API documentation.

## Testing
- Manual tests were performed using Swagger UI and Postman.
- Cucumber feature scenarios will be added to cover error cases and successful retrieval.
