### PR TITLE
Se implementan métodos de búsqueda/consulta de mascotas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /target/
+/.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>jackson-databind-nullable</artifactId>
             <version>0.2.6</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.15.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
@@ -1,0 +1,87 @@
+package io.zutun.samples.adapter.in.web;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.zutun.samples.adapter.in.web.response.PaginatedResponse;
+import io.zutun.samples.domain.Pet;
+import io.zutun.samples.usecases.SearchPetUseCase;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Pets", description = "Pets search operations")
+@Validated
+@RestController
+@RequestMapping("/v1/pets")
+@RequiredArgsConstructor
+public class SearchPetController {
+
+    private final SearchPetUseCase searchPetUseCase;
+
+    @Operation(
+            summary = "Find pet by Id",
+            description = "Find pet by Id",
+            tags = {"Pets"}
+    )
+    @Tag(name = "Pets", description = "Find pet by Id")
+    @GetMapping("/{petId}")
+    public ResponseEntity<Pet> findById(@PathVariable UUID petId) {
+        System.out.println("findPetById: " + petId);
+        Optional<Pet> pet = searchPetUseCase.findById(petId);
+         return pet.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+    
+    @Operation(
+            summary = "Find pets by given attributes",
+            description = "Find pet by name and/or age",
+            tags = {"Pets"}
+    )
+    @Tag(name = "Pets", description = "Find pet by Id")
+    @GetMapping
+    public ResponseEntity<PaginatedResponse<Pet>> findByAttributes(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Integer age,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int pagesize) {
+
+        PaginatedResponse<Pet> pets;
+        PetData petData = new PetData(name, age);
+
+        switch(petData) {
+            case PetData p when p.name() != null && p.age() != null -> {
+                System.out.println("Buscar por nombre y fnac: " + p.name() + " " + calculateBirthdate(p.age()));
+                pets = searchPetUseCase.findByNameAndBirthDate(p.name(), calculateBirthdate(p.age()), page, pagesize);
+            }
+            case PetData p when p.name() != null -> {
+                System.out.println("Buscar por nombre: " + p.name());
+                pets = searchPetUseCase.findByName(p.name(), page, pagesize);
+            }
+            case PetData p when p.age() != null -> {
+                System.out.println("Buscar por fnac: " + calculateBirthdate(p.age()));
+                pets = searchPetUseCase.findByBirthDate(calculateBirthdate(p.age()), page, pagesize);
+            }
+            default -> pets = searchPetUseCase.findAll(page, pagesize);
+        }
+        return ResponseEntity.ok(pets);
+    }
+
+    private static LocalDate calculateBirthdate(int age) {
+        return LocalDate.now().minusMonths(age * 12);
+    }
+
+}
+
+record PetData(String name, Integer age) {}
+

--- a/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
@@ -54,7 +54,7 @@ public class SearchPetController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false) Integer age,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int pagesize) {
+            @RequestParam(defaultValue = "5") int size) {
 
         PaginatedResponse<Pet> pets;
         PetData petData = new PetData(name, age);
@@ -62,17 +62,17 @@ public class SearchPetController {
         switch(petData) {
             case PetData p when p.name() != null && p.age() != null -> {
                 System.out.println("Buscar por nombre y fnac: " + p.name() + " " + calculateBirthdate(p.age()));
-                pets = searchPetUseCase.findByNameAndBirthDate(p.name(), calculateBirthdate(p.age()), page, pagesize);
+                pets = searchPetUseCase.findByNameAndBirthDate(p.name(), calculateBirthdate(p.age()), page, size);
             }
             case PetData p when p.name() != null -> {
                 System.out.println("Buscar por nombre: " + p.name());
-                pets = searchPetUseCase.findByName(p.name(), page, pagesize);
+                pets = searchPetUseCase.findByName(p.name(), page, size);
             }
             case PetData p when p.age() != null -> {
                 System.out.println("Buscar por fnac: " + calculateBirthdate(p.age()));
-                pets = searchPetUseCase.findByBirthDate(calculateBirthdate(p.age()), page, pagesize);
+                pets = searchPetUseCase.findByBirthDate(calculateBirthdate(p.age()), page, size);
             }
-            default -> pets = searchPetUseCase.findAll(page, pagesize);
+            default -> pets = searchPetUseCase.findAll(page, size);
         }
         return ResponseEntity.ok(pets);
     }

--- a/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.zutun.samples.adapter.in.web.response.PaginatedResponse;
 import io.zutun.samples.domain.Pet;
 import io.zutun.samples.usecases.SearchPetUseCase;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Pets", description = "Pets search operations")
@@ -52,7 +53,7 @@ public class SearchPetController {
     @GetMapping
     public ResponseEntity<PaginatedResponse<Pet>> findByAttributes(
             @RequestParam(required = false) String name,
-            @RequestParam(required = false) Integer age,
+            @RequestParam(required = false) @Min(0) Integer age,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size) {
 
@@ -74,7 +75,9 @@ public class SearchPetController {
             }
             default -> pets = searchPetUseCase.findAll(page, size);
         }
-        return ResponseEntity.ok(pets);
+        if(pets.getContent().isEmpty()) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } else return new ResponseEntity<>(pets, HttpStatus.OK);
     }
 
     private static LocalDate calculateBirthdate(int age) {

--- a/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/SearchPetController.java
@@ -48,7 +48,7 @@ public class SearchPetController {
             description = "Find pet by name and/or age",
             tags = {"Pets"}
     )
-    @Tag(name = "Pets", description = "Find pet by Id")
+    @Tag(name = "Pets", description = "Find pet by name and/or age")
     @GetMapping
     public ResponseEntity<PaginatedResponse<Pet>> findByAttributes(
             @RequestParam(required = false) String name,

--- a/src/main/java/io/zutun/samples/adapter/in/web/response/PaginatedResponse.java
+++ b/src/main/java/io/zutun/samples/adapter/in/web/response/PaginatedResponse.java
@@ -1,0 +1,22 @@
+package io.zutun.samples.adapter.in.web.response;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class PaginatedResponse<T> {
+    private List<T> content;
+    private int page;
+    private int pagesize;
+    private long totalElements;
+    private int totalPages;
+
+    public PaginatedResponse(List<T> content, int page, int pagesize, long totalElements, int totalPages) {
+        this.content = content;
+        this.page = page;
+        this.pagesize = pagesize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+}

--- a/src/main/java/io/zutun/samples/config/WebConfig.java
+++ b/src/main/java/io/zutun/samples/config/WebConfig.java
@@ -3,6 +3,7 @@ package io.zutun.samples.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +19,8 @@ public class WebConfig implements WebMvcConfigurer {
         return new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new Jdk8Module());
     }
 
 }

--- a/src/main/java/io/zutun/samples/service/PetSearchService.java
+++ b/src/main/java/io/zutun/samples/service/PetSearchService.java
@@ -1,0 +1,51 @@
+package io.zutun.samples.service;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import io.zutun.samples.adapter.in.web.response.PaginatedResponse;
+import io.zutun.samples.domain.Pet;
+import io.zutun.samples.usecases.SearchPetUseCase;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PetSearchService implements SearchPetUseCase {
+
+    private final PetsRepository repository;
+
+    public Optional<Pet> findById(UUID id) {
+        return repository.findById(id);
+    }
+
+    public PaginatedResponse<Pet> findAll(int page, int pagesize) {
+        Pageable pageable = PageRequest.of(page, pagesize);
+        Page<Pet> result = repository.findAll(pageable);
+        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+    }
+
+    public PaginatedResponse<Pet> findByName(String name, int page, int pagesize) {
+        Pageable pageable = PageRequest.of(page, pagesize);
+        Page<Pet> result = repository.findByNameIgnoreCase(name, pageable);
+        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+    }
+
+    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int pagesize) {
+        Pageable pageable = PageRequest.of(page, pagesize);
+        Page<Pet> result = repository.findByBirthDate(birthDate, pageable);
+        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+    }
+    
+    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int pagesize) {
+        Pageable pageable = PageRequest.of(page, pagesize);
+        Page<Pet> result = repository.findByNameIgnoreCaseAndBirthDate(name, birthDate, pageable);
+        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+    } 
+}
+

--- a/src/main/java/io/zutun/samples/service/PetSearchService.java
+++ b/src/main/java/io/zutun/samples/service/PetSearchService.java
@@ -24,28 +24,28 @@ public class PetSearchService implements SearchPetUseCase {
         return repository.findById(id);
     }
 
-    public PaginatedResponse<Pet> findAll(int page, int pagesize) {
-        Pageable pageable = PageRequest.of(page, pagesize);
+    public PaginatedResponse<Pet> findAll(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         Page<Pet> result = repository.findAll(pageable);
-        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+        return new PaginatedResponse<>(result.getContent(), page, size, result.getTotalElements(), result.getTotalPages());
     }
 
-    public PaginatedResponse<Pet> findByName(String name, int page, int pagesize) {
-        Pageable pageable = PageRequest.of(page, pagesize);
+    public PaginatedResponse<Pet> findByName(String name, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         Page<Pet> result = repository.findByNameIgnoreCase(name, pageable);
-        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+        return new PaginatedResponse<>(result.getContent(), page, size, result.getTotalElements(), result.getTotalPages());
     }
 
-    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int pagesize) {
-        Pageable pageable = PageRequest.of(page, pagesize);
+    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         Page<Pet> result = repository.findByBirthDate(birthDate, pageable);
-        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+        return new PaginatedResponse<>(result.getContent(), page, size, result.getTotalElements(), result.getTotalPages());
     }
     
-    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int pagesize) {
-        Pageable pageable = PageRequest.of(page, pagesize);
+    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
         Page<Pet> result = repository.findByNameIgnoreCaseAndBirthDate(name, birthDate, pageable);
-        return new PaginatedResponse<>(result.getContent(), page, pagesize, result.getTotalElements(), result.getTotalPages());
+        return new PaginatedResponse<>(result.getContent(), page, size, result.getTotalElements(), result.getTotalPages());
     } 
 }
 

--- a/src/main/java/io/zutun/samples/service/PetsRepository.java
+++ b/src/main/java/io/zutun/samples/service/PetsRepository.java
@@ -1,11 +1,22 @@
 package io.zutun.samples.service;
 
 import io.zutun.samples.domain.Pet;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Repository
 interface PetsRepository extends JpaRepository<Pet, UUID> {
+
+    Page<Pet> findByNameIgnoreCase(String name, Pageable pageable);
+    
+    Page<Pet> findByBirthDate(LocalDate birthDate, Pageable pageable);
+
+    Page<Pet> findByNameIgnoreCaseAndBirthDate(String name, LocalDate birthDate, Pageable pageable);
+
 }

--- a/src/main/java/io/zutun/samples/usecases/SearchPetUseCase.java
+++ b/src/main/java/io/zutun/samples/usecases/SearchPetUseCase.java
@@ -9,14 +9,14 @@ import io.zutun.samples.domain.Pet;
 
 public interface SearchPetUseCase {
 
-    public PaginatedResponse<Pet> findAll(int page, int pagesize);
+    public PaginatedResponse<Pet> findAll(int page, int size);
 
     public Optional<Pet> findById(UUID id);
 
-    public PaginatedResponse<Pet> findByName(String name, int page, int pagesize);
+    public PaginatedResponse<Pet> findByName(String name, int page, int size);
 
-    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int pagesize);
+    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int size);
 
-    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int pagesize);
+    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int size);
 
 }

--- a/src/main/java/io/zutun/samples/usecases/SearchPetUseCase.java
+++ b/src/main/java/io/zutun/samples/usecases/SearchPetUseCase.java
@@ -1,0 +1,22 @@
+package io.zutun.samples.usecases;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.zutun.samples.adapter.in.web.response.PaginatedResponse;
+import io.zutun.samples.domain.Pet;
+
+public interface SearchPetUseCase {
+
+    public PaginatedResponse<Pet> findAll(int page, int pagesize);
+
+    public Optional<Pet> findById(UUID id);
+
+    public PaginatedResponse<Pet> findByName(String name, int page, int pagesize);
+
+    public PaginatedResponse<Pet> findByBirthDate(LocalDate birthDate, int page, int pagesize);
+
+    public PaginatedResponse<Pet> findByNameAndBirthDate(String name, LocalDate birthDate, int page, int pagesize);
+
+}


### PR DESCRIPTION
1. Se crea controlador REST SearchPetController con los siguientes recursos:

**GET /v1/pets**
   QueryParams **name** (opcional), **age** (opcional), **page** (opcional, '0' por defecto), **size** (opcional, '5' por defecto)
   ** Implementa paginación
   Ejemplos:
      ​http://<server>:<port>/v1/pets?page=0&size=10 -> Lista todas las mascotas, la primera página en grupos de 10
      http://<server>:<port>/v1/pets?age=4  -> Lista todas las mascotas cuya edad sea 4 años
      http://<server>:<port>/v1/pets?name=SPOOKY -> Lista todas las mascotas de nombre 'Spooky' (no case sensitive)
      http://<server>:<port>/v1/pets?name=SPOOKY&age=1 -> Lista todas las mascotas de nombre 'Spooky' (no case sensitive) y de edad 1
     NOTA: Los parámetros page & size pueden complementar cualquiera de las consultas

**GET /v1/pets/{petId}**
     Ejemplo:
        ​http://<server>:<port>/v1/pets/1d29cee9-1ca7-40df-a299-8cc65df2baeb

2. Se crean servicios e interfaces relacionadas (SearchPetUseCase y PetSearchService)

3. Se extiende la clase PetsRepository con operaciones específicas para las consultas a través de JPA

4. Se crea clase de representación para respuesta paginada (PaginatedResponse)

5. Registro de dependencia y de módulo Jdk8Module() para habilitar el manejo de Optional<T>, el cual no viene habilitado por defecto. Esto soluciona fallos en tiempo de ejecución en la conversión de mensajes con Jackson
 
Excepción:
optional type java.util.Optional<java.lang.String> not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling



